### PR TITLE
Add service request and project confirmation features

### DIFF
--- a/artisan.js
+++ b/artisan.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
         requestServiceBtn.addEventListener('click', (event) => {
             event.preventDefault(); // Prevent default form submission
             if (selectedDate && typeof artisanId !== 'undefined') { // Check if artisanId is defined globally
-                window.location.href = `demande_service.php?id_prestataire=${artisanId}&date_debut=${selectedDate}`;
+                window.location.href = `demande_service.php?id_prestataire=${artisanId}&date_dispo=${selectedDate}`;
             } else {
                 alert('Please select an available date first.');
             }

--- a/artisan.php
+++ b/artisan.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require 'config.php';
 
 if (!isset($_GET['id'])) {
@@ -171,8 +172,18 @@ if ($is_available && in_array(date('Y-m-d'), $unavailableDates)) {
             if ($stmt_global_check->fetchColumn() > 0) {
                 $is_globally_unavailable = true;
             }
+
+            // Determine if the viewer can request a service (client or artisan not viewing own profile)
+            $can_request = false;
+            if (isset($_SESSION['id_utilisateur'])) {
+                $viewer_id = $_SESSION['id_utilisateur'];
+                $viewer_role = $_SESSION['role'];
+                if (($viewer_role === 'client' || $viewer_role === 'prestataire') && $viewer_id != $prestataire['id_utilisateur']) {
+                    $can_request = true;
+                }
+            }
             ?>
-            <?php if (!$is_available): ?>
+            <?php if (!$is_available || !$can_request): ?>
                 <button class="request-service-action-btn unavailable-btn" disabled>Indisponible</button>
             <?php else: ?>
                 <button class="request-service-action-btn" id="requestServiceBtn" data-prestataire-id="<?= $id_prestataire ?>" disabled>Demande De Service</button>


### PR DESCRIPTION
## Summary
- allow logged-in artisans or clients to request services from artisan page
- auto-create a Client profile for artisans acting as clients
- prefill request form date via GET param
- extend client dashboard with accepted request handling and meeting confirmation
- allow project completion confirmation on both dashboards
- enable meeting confirmation in artisan dashboard

## Testing
- `php -l artisan.php`
- `php -l artisan.js`
- `php -l demande_service.php`
- `php -l client_Dashboard.php`
- `php -l artisan_dashboard.php`
- `php -l payment_page.php`

------
https://chatgpt.com/codex/tasks/task_b_685091ad2e00832c99b7440b35f31bf5